### PR TITLE
Swap annotation bit width

### DIFF
--- a/DianaModules/utils/onnx.py
+++ b/DianaModules/utils/onnx.py
@@ -43,8 +43,8 @@ class DianaAnnotator(ONNXAnnotator):
                 ):
                     weight_bits = (
                         8
-                        if pytorch_module.is_analog == torch.Tensor([1])
-                        else 3
+                        if not pytorch_module.is_analog == torch.Tensor([1])
+                        else 2
                     )  # check register buffer inside conv layer to know if it's analog or not
                     bias_bits = 32
                     annotations.append(


### PR DESCRIPTION
Analog is 2 bits now, and in the format both bit widths were swapped

CC @maartenvds @tverbele 